### PR TITLE
feat(renderer): add PixiJS renderer for board, tiles, animations, particles

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,12 @@
   </div>
 
   <!-- ===================== SCRIPTS ===================== -->
+  <script src="https://cdn.jsdelivr.net/npm/pixi.js@8/dist/pixi.min.js"></script>
+  <script src="js/renderer/PixiRenderer.js"></script>
+  <script src="js/renderer/TileSprite.js"></script>
+  <script src="js/renderer/AnimationManager.js"></script>
+  <script src="js/renderer/ParticleManager.js"></script>
+  <script src="js/renderer/BoardRenderer.js"></script>
   <script src="js/audio.js"></script>
   <script src="js/domino.js"></script>
   <script src="js/board.js"></script>

--- a/js/board.js
+++ b/js/board.js
@@ -93,13 +93,9 @@ const Board = (() => {
   // ---------- Internal rendering ----------
 
   function _render() {
-    const boardEl = document.getElementById('board');
-    if (!boardEl) return;
-    boardEl.innerHTML = '';
-    chain.forEach(entry => {
-      const el = UI.createTileElement(entry.tile, { placed: true });
-      boardEl.appendChild(el);
-    });
+    if (window.BoardRenderer) {
+      BoardRenderer.render([...chain]);
+    }
   }
 
   return { reset, isEmpty, placeFirst, place, validEnds, canPlay,

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,9 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', () => {
+  PixiRenderer.init().then(() => {
+    BoardRenderer.init();
+  });
 
   // ================================================================
   // AUDIO — init on first user interaction to satisfy browser policy
@@ -161,7 +164,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // ================================================================
   window.GameAudio = {
     onTilePlaced()  { Audio.play('place'); },
-    onRoundWin()    { Audio.play('win');   },
+    onRoundWin()    {
+      Audio.play('win');
+      const app = PixiRenderer.getApp();
+      if (app) ParticleManager.burst(app.screen.width / 2, app.screen.height / 2);
+    },
     onRoundLose()   { Audio.play('lose');  },
   };
 

--- a/js/renderer/AnimationManager.js
+++ b/js/renderer/AnimationManager.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const AnimationManager = (() => {
+
+  function animateTileIn(sprite, targetX, targetY) {
+    const app = PixiRenderer.getApp();
+    if (!app) { sprite.x = targetX; sprite.y = targetY; return; }
+
+    sprite.x     = targetX - 50;
+    sprite.y     = targetY;
+    sprite.alpha = 0;
+
+    let progress = 0;
+
+    const tick = () => {
+      progress = Math.min(1, progress + 0.09);
+      sprite.x     = targetX - 50 + 50 * _easeOut(progress);
+      sprite.alpha = progress;
+      if (progress >= 1) app.ticker.remove(tick);
+    };
+
+    app.ticker.add(tick);
+  }
+
+  function _easeOut(t) {
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  return { animateTileIn };
+})();

--- a/js/renderer/BoardRenderer.js
+++ b/js/renderer/BoardRenderer.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const BoardRenderer = (() => {
+  let _container = null;
+  let _lastChainLength = 0;
+
+  function init() {
+    const stage = PixiRenderer.getStage();
+    if (!stage) return;
+    _container = new PIXI.Container();
+    stage.addChild(_container);
+  }
+
+  function render(chain) {
+    if (!_container) return;
+    _container.removeChildren();
+
+    if (!chain || chain.length === 0) {
+      _lastChainLength = 0;
+      return;
+    }
+
+    const app    = PixiRenderer.getApp();
+    const stageW = app.screen.width;
+    const stageH = app.screen.height;
+    const GAP    = 4;
+    const tW     = TileSprite.TILE_W;
+    const tH     = TileSprite.TILE_H;
+    const rowMax = Math.floor((stageW - 16) / (tW + GAP));
+
+    const isNew  = chain.length > _lastChainLength;
+    _lastChainLength = chain.length;
+
+    chain.forEach((entry, i) => {
+      const col    = i % rowMax;
+      const row    = Math.floor(i / rowMax);
+      const totalRowTiles = Math.min(chain.length - row * rowMax, rowMax);
+      const rowW   = totalRowTiles * (tW + GAP) - GAP;
+      const startX = (stageW - rowW) / 2;
+      const startY = (stageH - tH) / 2 - row * (tH + GAP);
+
+      const targetX = startX + col * (tW + GAP);
+      const targetY = startY;
+
+      const sprite = TileSprite.create(entry.tile);
+
+      // Animate the last tile in; place all others immediately
+      if (isNew && i === chain.length - 1) {
+        AnimationManager.animateTileIn(sprite, targetX, targetY);
+      } else {
+        sprite.x = targetX;
+        sprite.y = targetY;
+      }
+
+      _container.addChild(sprite);
+    });
+  }
+
+  return { init, render };
+})();

--- a/js/renderer/ParticleManager.js
+++ b/js/renderer/ParticleManager.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const ParticleManager = (() => {
+  const COLORS = [0xffd700, 0xff6b6b, 0x4ecdc4, 0x45b7d1, 0x96ceb4, 0xffeaa7, 0xe8b84b];
+
+  function burst(x, y, count = 50) {
+    const app = PixiRenderer.getApp();
+    if (!app) return;
+
+    const particles = Array.from({ length: count }, () => {
+      const p = new PIXI.Graphics();
+      const size = 4 + Math.random() * 5;
+      p.rect(0, 0, size, size);
+      p.fill(COLORS[Math.floor(Math.random() * COLORS.length)]);
+      p.x  = x;
+      p.y  = y;
+      p.rotation = Math.random() * Math.PI * 2;
+      p._vx      = (Math.random() - 0.5) * 14;
+      p._vy      = (Math.random() - 1.8) * 10;
+      p._gravity = 0.45;
+      p._life    = 1;
+      app.stage.addChild(p);
+      return p;
+    });
+
+    const tick = () => {
+      let anyAlive = false;
+      particles.forEach(p => {
+        if (p._life <= 0) return;
+        p._vy += p._gravity;
+        p.x   += p._vx;
+        p.y   += p._vy;
+        p._life  -= 0.018;
+        p.alpha   = Math.max(0, p._life);
+        p.rotation += 0.08;
+        if (p._life > 0) anyAlive = true;
+        else app.stage.removeChild(p);
+      });
+      if (!anyAlive) app.ticker.remove(tick);
+    };
+
+    app.ticker.add(tick);
+  }
+
+  return { burst };
+})();

--- a/js/renderer/PixiRenderer.js
+++ b/js/renderer/PixiRenderer.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const PixiRenderer = (() => {
+  let _app = null;
+
+  async function init() {
+    const wrapper = document.getElementById('board-wrapper');
+    if (!wrapper) return;
+
+    _app = new PIXI.Application();
+    await _app.init({
+      backgroundAlpha: 0,
+      width:  wrapper.clientWidth  || 800,
+      height: wrapper.clientHeight || 400,
+      antialias: true,
+      resolution: window.devicePixelRatio || 1,
+      autoDensity: true,
+    });
+
+    _app.canvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;';
+    wrapper.appendChild(_app.canvas);
+
+    // Hide the DOM board — PixiJS canvas takes over
+    const boardEl = document.getElementById('board');
+    if (boardEl) boardEl.style.display = 'none';
+
+    window.addEventListener('resize', _onResize);
+  }
+
+  function _onResize() {
+    const wrapper = document.getElementById('board-wrapper');
+    if (!_app || !wrapper) return;
+    _app.renderer.resize(wrapper.clientWidth, wrapper.clientHeight);
+    if (window.BoardRenderer) BoardRenderer.render();
+  }
+
+  function getApp()   { return _app; }
+  function getStage() { return _app ? _app.stage : null; }
+
+  return { init, getApp, getStage };
+})();

--- a/js/renderer/TileSprite.js
+++ b/js/renderer/TileSprite.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const TileSprite = (() => {
+  const TILE_W  = 52;
+  const TILE_H  = 104;
+  const HALF_H  = TILE_H / 2;
+  const PAD     = 6;
+  const PIP_R   = 4;
+
+  // Pip slot indices map to a 3×3 grid (slots 0–8):
+  //  0 1 2
+  //  3 4 5
+  //  6 7 8
+  const PIP_LAYOUTS = {
+    0: [],
+    1: [4],
+    2: [0, 8],
+    3: [0, 4, 8],
+    4: [0, 2, 6, 8],
+    5: [0, 2, 4, 6, 8],
+    6: [0, 2, 3, 5, 6, 8],
+  };
+
+  function create(tile) {
+    const container = new PIXI.Container();
+
+    // Tile body
+    const bg = new PIXI.Graphics();
+    bg.roundRect(0, 0, TILE_W, TILE_H, 5);
+    bg.fill(0xf5f0e8);
+    bg.stroke({ color: 0xc8b99a, width: 1.5 });
+    container.addChild(bg);
+
+    // Divider
+    const div = new PIXI.Graphics();
+    div.moveTo(PAD, HALF_H);
+    div.lineTo(TILE_W - PAD, HALF_H);
+    div.stroke({ color: 0x8a7a65, width: 1.5 });
+    container.addChild(div);
+
+    // Pips
+    _drawHalf(container, tile.high, 0);
+    _drawHalf(container, tile.low,  HALF_H);
+
+    return container;
+  }
+
+  function _drawHalf(container, value, yBase) {
+    const slots  = PIP_LAYOUTS[value] ?? [];
+    const cellW  = (TILE_W - PAD * 2) / 3;
+    const cellH  = (HALF_H - PAD * 2) / 3;
+
+    slots.forEach(slot => {
+      const col = slot % 3;
+      const row = Math.floor(slot / 3);
+      const cx  = PAD + col * cellW + cellW / 2;
+      const cy  = yBase + PAD + row * cellH + cellH / 2;
+
+      const pip = new PIXI.Graphics();
+      pip.circle(cx, cy, PIP_R);
+      pip.fill(0x1a1a1a);
+      container.addChild(pip);
+    });
+  }
+
+  return { create, TILE_W, TILE_H };
+})();


### PR DESCRIPTION
## Summary
- Added PixiJS canvas renderer to replace DOM-based board tile rendering
- TileSprite draws domino tiles with accurate pip layouts using PixiJS graphics
- BoardRenderer lays out the full tile chain centered on the canvas
- AnimationManager adds slide-in animation for each newly placed tile
- ParticleManager fires a confetti burst on round win

## Test plan
- [ ] Start a game vs CPU and confirm tiles appear on the board canvas
- [ ] Play a tile and confirm the slide-in animation works
- [ ] Win a round and confirm the confetti particle burst fires
- [ ] Confirm player hand still renders correctly at the bottom (DOM)
- [ ] Confirm score bar, boneyard, and overlays are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)